### PR TITLE
DICOM repository GET scenario fix-up

### DIFF
--- a/hsdp/resource_dicom_repository.go
+++ b/hsdp/resource_dicom_repository.go
@@ -86,7 +86,7 @@ func resourceDICOMRepositoryRead(_ context.Context, d *schema.ResourceData, m in
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	_ = d.Set("organization_id", repo.OrganizationID)
+	_ = d.Set("repository_organization_id", repo.OrganizationID)
 	_ = d.Set("object_store_id", repo.ActiveObjectStoreID)
 	return diags
 }


### PR DESCRIPTION
When running GET operation for DICOM store repository, organization_id from API GET body was overwriting root organization ID (which should not be touched). In contrast it was not correctly setting repository_organization_id.

As a result subsequent operations were broken in case of shared setup.
