### PR TITLE
SSH agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## v0.20.4
+- DICOM Gateway: various fixes based on API changes
+- Container Host: support for SSH-agent authentication
+
 ## v0.20.3
 - DICOM Gateway: don't propagate secure toggle field
 

--- a/docs/resources/container_host.md
+++ b/docs/resources/container_host.md
@@ -16,7 +16,6 @@ resource "hsdp_container_host" "zahadoom" {
   user_groups = var.user_groups
   security_groups = ["analytics", var.user]
 
-  bastion_host = var.bastion_host
   user = var.user
   private_key = var.private_key
 

--- a/docs/resources/container_host_exec.md
+++ b/docs/resources/container_host_exec.md
@@ -11,10 +11,9 @@ The following example uses the internal provisioning support for bootstrapping a
 ```hcl
 resource "hsdp_container_host_exec" "init" {
   host = hsdp_container_host.mybox.private_ip
-  bastion_host = var.bastion_host
   user = var.user
-  private_key = var.private_key
-
+  # an SSH agent should be running with the SSH private key loaded
+   
   file {
     content = "echo Hello world"
     destination = "/tmp/hello.sh"
@@ -32,7 +31,7 @@ resource "hsdp_container_host_exec" "init" {
 The following arguments are supported:
 
 * `user` - (Required) The username to use for provision activities using SSH
-* `private_key` - (Required) The SSH private key to use for provision activities
+* `private_key` - (Optional) The SSH private key to use for provision activities. When not provided an ssh-agent should be available.
 * `file` - (Optional) Block specifying content to be written to the container host after creation
 * `commands` - (Required, list(string)) List of commands to execute after creation of container host
 * `bastion_host` - (Optional) The bastion host to use.  When not set, this will be deduced from the container host location

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/philips-labs/ferrite v0.1.2
 	github.com/philips-labs/siderite v0.11.0
-	github.com/philips-software/go-hsdp-api v0.44.1-0.20210922181109-af52e2fd3532
+	github.com/philips-software/go-hsdp-api v0.44.1-0.20210923052709-efd30fe3f93e
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -945,8 +945,6 @@ github.com/philips-software/gautocloud-connectors v0.4.0/go.mod h1:k5VG78BLnDI75
 github.com/philips-software/go-hsdp-api v0.20.0/go.mod h1:agJtsgjb1W4xq5cVUdk06uUVETKO1nKZAZJ4Y1Dumg4=
 github.com/philips-software/go-hsdp-api v0.38.1-0.20210428141703-9f4371331e80/go.mod h1:vzZX4kCmgVwuJcAmd75Yeh/tNu1dNnBRbyau7CFWsuQ=
 github.com/philips-software/go-hsdp-api v0.42.2/go.mod h1:8/X/HGcmxfWMicqeVADZWwmPLGLA8hbqLr22w+ku5qE=
-github.com/philips-software/go-hsdp-api v0.44.1-0.20210921112738-5641941172da h1:bv6ksoc3x0jhhva7AW8FwDL4O3Ey/eohAAfEc5NbCjo=
-github.com/philips-software/go-hsdp-api v0.44.1-0.20210921112738-5641941172da/go.mod h1:g30qx/PUOGEd6/1zf4/Ym+EV6sbpNc+kmofmH2j09A4=
 github.com/philips-software/go-hsdp-api v0.44.1-0.20210922181109-af52e2fd3532 h1:suRFHYv9+RHxIllJni9ooqbTufv70DFN6dZUjFv2vV8=
 github.com/philips-software/go-hsdp-api v0.44.1-0.20210922181109-af52e2fd3532/go.mod h1:g30qx/PUOGEd6/1zf4/Ym+EV6sbpNc+kmofmH2j09A4=
 github.com/philips-software/go-hsdp-signer v1.3.0 h1:Si1voDE/GHzthmxpasPdntbu8aUW6EYJfI6gHVf7BCc=

--- a/go.sum
+++ b/go.sum
@@ -947,6 +947,8 @@ github.com/philips-software/go-hsdp-api v0.38.1-0.20210428141703-9f4371331e80/go
 github.com/philips-software/go-hsdp-api v0.42.2/go.mod h1:8/X/HGcmxfWMicqeVADZWwmPLGLA8hbqLr22w+ku5qE=
 github.com/philips-software/go-hsdp-api v0.44.1-0.20210922181109-af52e2fd3532 h1:suRFHYv9+RHxIllJni9ooqbTufv70DFN6dZUjFv2vV8=
 github.com/philips-software/go-hsdp-api v0.44.1-0.20210922181109-af52e2fd3532/go.mod h1:g30qx/PUOGEd6/1zf4/Ym+EV6sbpNc+kmofmH2j09A4=
+github.com/philips-software/go-hsdp-api v0.44.1-0.20210923052709-efd30fe3f93e h1:jWlkXvEO4OmpkKPhdzkbUWr33JhA8oJPo8jAQX2LNKE=
+github.com/philips-software/go-hsdp-api v0.44.1-0.20210923052709-efd30fe3f93e/go.mod h1:g30qx/PUOGEd6/1zf4/Ym+EV6sbpNc+kmofmH2j09A4=
 github.com/philips-software/go-hsdp-signer v1.3.0 h1:Si1voDE/GHzthmxpasPdntbu8aUW6EYJfI6gHVf7BCc=
 github.com/philips-software/go-hsdp-signer v1.3.0/go.mod h1:/QehZ/+Aks2t1TFpjhF/7ZSB8PJIIJHzLc03rOqwLw0=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=

--- a/hsdp/resource_container_host.go
+++ b/hsdp/resource_container_host.go
@@ -162,15 +162,13 @@ func resourceContainerHost() *schema.Resource {
 				Optional: true,
 			},
 			"user": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"private_key"},
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"private_key": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				RequiredWith: []string{"user"},
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"keep_failed_instances": {
 				Type:     schema.TypeBool,
@@ -339,9 +337,6 @@ func resourceContainerHostCreate(ctx context.Context, d *schema.ResourceData, m 
 		if user == "" {
 			return diag.FromErr(fmt.Errorf("user must be set when '%s' is specified", commandsField))
 		}
-		if privateKey == "" {
-			return diag.FromErr(fmt.Errorf("privateKey must be set when '%s' is specified", commandsField))
-		}
 	}
 
 	ch, resp, err := client.Create(tagName,
@@ -427,14 +422,16 @@ func resourceContainerHostCreate(ctx context.Context, d *schema.ResourceData, m 
 		User:   user,
 		Server: privateIP,
 		Port:   "22",
-		Key:    privateKey,
 		Proxy:  http.ProxyFromEnvironment,
 		Bastion: easyssh.DefaultConfig{
 			User:   user,
 			Server: bastionHost,
 			Port:   "22",
-			Key:    privateKey,
 		},
+	}
+	if privateKey != "" {
+		ssh.Key = privateKey
+		ssh.Bastion.Key = privateKey
 	}
 
 	// Create files

--- a/hsdp/resource_container_host.go
+++ b/hsdp/resource_container_host.go
@@ -170,6 +170,11 @@ func resourceContainerHost() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 			},
+			"agent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"keep_failed_instances": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -257,7 +262,7 @@ func resourceContainerHost() *schema.Resource {
 			},
 			"tags": tagsSchema(),
 		},
-		SchemaVersion: 3,
+		SchemaVersion: 4,
 	}
 }
 
@@ -306,6 +311,7 @@ func resourceContainerHostCreate(ctx context.Context, d *schema.ResourceData, m 
 	image := d.Get("image").(string)
 	user := d.Get("user").(string)
 	privateKey := d.Get("private_key").(string)
+	agent := d.Get("agent").(bool)
 
 	if subnetType == "" {
 		subnetType = "private"
@@ -430,6 +436,9 @@ func resourceContainerHostCreate(ctx context.Context, d *schema.ResourceData, m 
 		},
 	}
 	if privateKey != "" {
+		if agent {
+			return diag.FromErr(fmt.Errorf("'agent' is enabled so not expecting a private key to be set"))
+		}
 		ssh.Key = privateKey
 		ssh.Bastion.Key = privateKey
 	}

--- a/hsdp/resource_container_host_exec.go
+++ b/hsdp/resource_container_host_exec.go
@@ -45,7 +45,7 @@ The ` + "`triggers`" + ` argument allows specifying an arbitrary set of values t
 			},
 			"private_key": {
 				Type:      schema.TypeString,
-				Required:  true,
+				Optional:  true,
 				ForceNew:  true,
 				Sensitive: true,
 			},
@@ -127,9 +127,6 @@ func resourceContainerHostExecCreate(_ context.Context, d *schema.ResourceData, 
 		if user == "" {
 			return diag.FromErr(fmt.Errorf("user must be set when '%s' is specified", commandsField))
 		}
-		if privateKey == "" {
-			return diag.FromErr(fmt.Errorf("privateKey must be set when '%s' is specified", commandsField))
-		}
 	}
 	// Collect SSH details
 	privateIP := host
@@ -145,6 +142,10 @@ func resourceContainerHostExecCreate(_ context.Context, d *schema.ResourceData, 
 			Port:   "22",
 			Key:    privateKey,
 		},
+	}
+	if privateKey != "" {
+		ssh.Key = privateKey
+		ssh.Bastion.Key = privateKey
 	}
 
 	// Provision files

--- a/hsdp/resource_container_host_exec.go
+++ b/hsdp/resource_container_host_exec.go
@@ -20,6 +20,7 @@ The ` + "`triggers`" + ` argument allows specifying an arbitrary set of values t
 		CreateContext: resourceContainerHostExecCreate,
 		Read:          resourceContainerHostExecRead,
 		Delete:        resourceConainterHostDelete,
+		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
 			"triggers": {
@@ -48,6 +49,12 @@ The ` + "`triggers`" + ` argument allows specifying an arbitrary set of values t
 				Optional:  true,
 				ForceNew:  true,
 				Sensitive: true,
+			},
+			"agent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 			commandsField: {
 				Type:     schema.TypeList,
@@ -112,6 +119,7 @@ func resourceContainerHostExecCreate(_ context.Context, d *schema.ResourceData, 
 	user := d.Get("user").(string)
 	privateKey := d.Get("private_key").(string)
 	host := d.Get("host").(string)
+	agent := d.Get("agent").(bool)
 
 	// Fetch files first before starting provisioning
 	createFiles, diags := collectFilesToCreate(d)
@@ -144,6 +152,9 @@ func resourceContainerHostExecCreate(_ context.Context, d *schema.ResourceData, 
 		},
 	}
 	if privateKey != "" {
+		if agent {
+			return diag.FromErr(fmt.Errorf("'agent' is enabled so not expecting a private key to be set"))
+		}
 		ssh.Key = privateKey
 		ssh.Bastion.Key = privateKey
 	}


### PR DESCRIPTION
The recommended approach is to load your SSH private in an
SSH-agent process. The provider can leverage this. A future
release will start emitting warnings when loading the private key.