### PR TITLE
Refactor debug writer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ arguments in its provider block. The following environment variables are recogni
 | HSDP_IAM_SERVICE_ID          | service_id          | Optional |             |
 | HSDP_IAM_SERVICE_PRIVATE_KEY | service_private_key | Optional |             |
 | HSDP_IAM_ORG_ADMIN_USERNAME  | org_admin_username  | Optional |             |
-| HSDP_IAM_ORG_ADMIN_PASSWORD  | org_admin_password  | Optional |
+| HSDP_IAM_ORG_ADMIN_PASSWORD  | org_admin_password  | Optional |             |
 | HSDP_IAM_OAUTH2_CLIENT_ID    | oauth2_client_id    | Optional |             |
 | HSDP_IAM_OAUTH2_PASSWORD     | oauth2_password     | Optional |             |
 | HSDP_SHARED_KEY              | shared_key          | Optional |             |
@@ -48,6 +48,7 @@ arguments in its provider block. The following environment variables are recogni
 | HSDP_UAA_USERNAME            | uaa_username        | Optional |             |
 | HSDP_UAA_PASSWORD            | uaa_password        | Optional |             |
 | HSDP_DEBUG_LOG               | debug_log           | Optional |             |
+| HSDP_DEBUG_STDERR            | debug_stderr        | Optional |             |
 
 ## Argument Reference
 
@@ -77,3 +78,4 @@ In addition to generic provider arguments (e.g. alias and version), the followin
 * `cartel_secret` - (Optional) The cartel secret as provided by HSDP.
 * `retry_max` - (Optional) Integer, when > 0 will use a retry-able HTTP client and retry requests when applicable.
 * `debug_log` - (Optional) If set to a path, when debug is enabled outputs details to this file
+* `debug_stderr` - (Optional) If set to true sends debug logs to `stderr`

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/loafoe/easyssh-proxy/v2 v2.0.4
 	github.com/loafoe/ferrite v0.2.0
 	github.com/philips-labs/siderite v0.12.2
-	github.com/philips-software/go-hsdp-api v0.78.7
+	github.com/philips-software/go-hsdp-api v0.79.0
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -749,10 +749,8 @@ github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG
 github.com/philips-labs/siderite v0.12.2 h1:V8v3Dcn/TUZvqfcCZ9EZ/E1aWXfcckayAuFwEYVzpvU=
 github.com/philips-labs/siderite v0.12.2/go.mod h1:wDjyR2ecI8z9S/uw4v7XCtgYK1Vr/eNE1Dnqmxr0wzo=
 github.com/philips-software/go-hsdp-api v0.50.2/go.mod h1:+/oOyI8Equm7/YcUHJ+PO3HO4U92JcAAoOs5DYRRkIc=
-github.com/philips-software/go-hsdp-api v0.78.6 h1:7BfVAdWodZ0ekzWVaq+mT5wtFfPCkR+CcAUNK4M0RaI=
-github.com/philips-software/go-hsdp-api v0.78.6/go.mod h1:J9j11CrQR7OXcvsSo+/kE20mkKpAuqB1dxVnXQETsf4=
-github.com/philips-software/go-hsdp-api v0.78.7 h1:NyGvZ0TSrTfVEYwA6ZdDpWghoBjGuHR5uhcZqYucVRE=
-github.com/philips-software/go-hsdp-api v0.78.7/go.mod h1:J9j11CrQR7OXcvsSo+/kE20mkKpAuqB1dxVnXQETsf4=
+github.com/philips-software/go-hsdp-api v0.79.0 h1:aiQ2o5xdSvBtZeSnalodQvgADQKHY/MgFdiKq7um+OE=
+github.com/philips-software/go-hsdp-api v0.79.0/go.mod h1:J9j11CrQR7OXcvsSo+/kE20mkKpAuqB1dxVnXQETsf4=
 github.com/philips-software/go-hsdp-signer v1.4.0 h1:yg7UILhmI4xJhr/tQiAiQwJL0EZFvLuMqpH2GZ9ygY4=
 github.com/philips-software/go-hsdp-signer v1.4.0/go.mod h1:/QehZ/+Aks2t1TFpjhF/7ZSB8PJIIJHzLc03rOqwLw0=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/internal/services/function/resource_function.go
+++ b/internal/services/function/resource_function.go
@@ -617,7 +617,7 @@ func newIronClient(d *schema.ResourceData, m interface{}) (*iron.Client, *iron.C
 		ProjectID: cfg["project_id"],
 		Token:     cfg["token"],
 		UserID:    cfg["user_id"],
-		DebugLog:  c.DebugLog,
+		DebugLog:  c.DebugWriter,
 		ClusterInfo: []iron.ClusterInfo{
 			{
 				ClusterID:   cfg["cluster_info_0_cluster_id"],

--- a/internal/services/iam/application/resource_iam_application.go
+++ b/internal/services/iam/application/resource_iam_application.go
@@ -186,8 +186,12 @@ func resourceIAMApplicationDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 	waitForDelete := d.Get("wait_for_delete").(bool)
 
-	ok, _, err := client.Applications.DeleteApplication(*app)
+	ok, resp, err := client.Applications.DeleteApplication(*app)
 	if err != nil {
+		if resp.StatusCode() == http.StatusNotFound { // Gone already
+			d.SetId("")
+			return diags
+		}
 		return diag.FromErr(err)
 	}
 	if !ok {
@@ -207,6 +211,7 @@ func resourceIAMApplicationDelete(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(fmt.Errorf("waiting for delete: %w", err))
 		}
 	}
+	d.SetId("")
 	return diags
 }
 

--- a/internal/services/iam/data_source_iam_token.go
+++ b/internal/services/iam/data_source_iam_token.go
@@ -38,12 +38,11 @@ func dataSourceIAMTokenRead(_ context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId("token-" + client.BaseIAMURL().Host)
 	token, err := client.Token()
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	d.SetId("token-" + client.BaseIAMURL().Host)
 	_ = d.Set("access_token", token)
 	_ = d.Set("expires_at", client.Expires())
 	_ = d.Set("id_token", client.IDToken())


### PR DESCRIPTION
Introduces a new `debug_stderr` provider argument which allows debug logs to be written to os.Stderr. This is helpful when the provider is running in a container environment e.g. when wrapped as a Crossplane provider

Co-authored-by: Marco Franssen <marco.franssen@philips.com>
Signed-off-by: Andy Lo-A-Foe <andy.loafoe@gmail.com>