### PR TITLE
FET-128 Support id only importing of user resources

### DIFF
--- a/docs/resources/iam_user.md
+++ b/docs/resources/iam_user.md
@@ -56,6 +56,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The GUID of the user
+* `access_status` - Reflects the access we have to the (existing) user. Possible values are `none`, `id_only`, `full`
 
 ## Import
 


### PR DESCRIPTION
This is used in the Crossplane provider to support ObserveOnly claims where only the UUID is required.